### PR TITLE
Add fair (ensemble-size adjusted) CRPS option to metric="crps"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ New Features
   fair Continuous Ranked Probability Score of Ferro (2014), giving an
   unbiased estimate that is comparable across ensembles of different size, e.g.
   ``HindcastEnsemble.verify(metric="crps", fair=True, ...)``.
-  `Aaron Spring`_
+  (:pr:`22`) `Aaron Spring`_
 
 
 Internals/Minor Fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ What's New
     # cut border when saving (for maps)
     mpl.rcParams["savefig.bbox"] = "tight"
 
+New Features
+------------
+- Add ``fair`` option to ``metric="crps"`` computing the ensemble-size adjusted
+  fair Continuous Ranked Probability Score of Ferro (2014), giving an
+  unbiased estimate that is comparable across ensembles of different size, e.g.
+  ``HindcastEnsemble.verify(metric="crps", fair=True, ...)``.
+  `Aaron Spring`_
+
+
 Internals/Minor Fixes
 ---------------------
 - Fix broken GEFS link (:pr:`807`) `Trevor Gamblin`_

--- a/climpred/metrics.py
+++ b/climpred/metrics.py
@@ -2890,11 +2890,14 @@ def _crps_ensemble_fair(
 
     where :math:`x_m` are the ensemble members and :math:`o` the verification.
     This makes scores comparable across ensembles of different size. Requires at
-    least two members. The pairwise spread term builds an :math:`M \times M` array,
-    so memory scales with the square of the ensemble size.
+    least two members; :math:`M` is counted per forecast excluding ``NaN`` members,
+    so ragged ensembles are handled correctly. The pairwise spread term builds an
+    :math:`M \times M` array, so memory scales with the square of the ensemble size.
     """
     skill = abs(forecast - verif).mean(member_dim)
-    M = forecast.sizes[member_dim]
+    # count non-NaN members per forecast so ragged ensembles normalize correctly,
+    # matching scores.probability.crps_for_ensemble(method="fair").
+    M = forecast.notnull().sum(member_dim)
     forecast_i = forecast.rename({member_dim: "__i"})
     forecast_j = forecast.rename({member_dim: "__j"})
     spread = abs(forecast_i - forecast_j).sum(["__i", "__j"]) / (2 * M * (M - 1))

--- a/climpred/metrics.py
+++ b/climpred/metrics.py
@@ -2867,6 +2867,43 @@ __threshold_brier_score = Metric(
 )
 
 
+def _crps_ensemble_fair(
+    verif: xr.Dataset,
+    forecast: xr.Dataset,
+    dim: List[str],
+    member_dim: str = "member",
+    weights: Optional[xr.Dataset] = None,
+    keep_attrs: bool = False,
+) -> xr.Dataset:
+    r"""Fair (ensemble-size adjusted) Continuous Ranked Probability Score.
+
+    The standard ensemble CRPS estimator used by
+    :py:func:`.xskillscore.crps_ensemble` is biased for finite ensemble size
+    :math:`M`; the bias vanishes only as :math:`M \to \infty`. The fair estimator
+    of :cite:t:`Ferro2014` corrects this by dividing the ensemble spread term by
+    :math:`M(M-1)` instead of :math:`M^{2}`, yielding an unbiased estimate of the
+    CRPS that the same ensemble would achieve with infinitely many members:
+
+    .. math::
+        CRPS_{fair} = \frac{1}{M} \sum_{m=1}^{M} |x_m - o|
+            - \frac{1}{2M(M-1)} \sum_{i=1}^{M} \sum_{j=1}^{M} |x_i - x_j|,
+
+    where :math:`x_m` are the ensemble members and :math:`o` the verification.
+    This makes scores comparable across ensembles of different size. Requires at
+    least two members. The pairwise spread term builds an :math:`M \times M` array,
+    so memory scales with the square of the ensemble size.
+    """
+    skill = abs(forecast - verif).mean(member_dim)
+    M = forecast.sizes[member_dim]
+    forecast_i = forecast.rename({member_dim: "__i"})
+    forecast_j = forecast.rename({member_dim: "__j"})
+    spread = abs(forecast_i - forecast_j).sum(["__i", "__j"]) / (2 * M * (M - 1))
+    res = skill - spread
+    if weights is not None:
+        return res.weighted(weights).mean(dim, keep_attrs=keep_attrs)
+    return res.mean(dim, keep_attrs=keep_attrs)
+
+
 def _crps(
     forecast: xr.Dataset,
     verif: xr.Dataset,
@@ -2899,7 +2936,11 @@ def _crps(
         verif: Verification data without ``member`` dim.
         dim: Dimension to apply metric over. Expects at least
             ``member``. Other dimensions are passed to ``xskillscore`` and averaged.
-        metric_kwargs: optional, see :py:func:`.xskillscore.crps_ensemble`
+        metric_kwargs: optional, see :py:func:`.xskillscore.crps_ensemble`.
+            If ``fair=True`` is passed, the ensemble-size adjusted fair CRPS of
+            :cite:t:`Ferro2014` is computed instead, giving an unbiased estimate
+            that is comparable across ensembles of different size (requires at least
+            two members). Defaults to ``fair=False``.
 
     Notes:
         +-----------------+-----------+
@@ -2914,6 +2955,7 @@ def _crps(
 
     References:
         * :cite:t:`Matheson1976`
+        * :cite:t:`Ferro2014` (for ``fair=True``)
         * https://www.lokad.com/continuous-ranked-probability-score
 
     See also:
@@ -2945,6 +2987,17 @@ def _crps(
     """
     dim = _remove_member_from_dim_or_raise(dim)
     # switch positions because xskillscore.crps_ensemble(verif, forecasts)
+    metric_kwargs = dict(metric_kwargs)
+    if metric_kwargs.pop("fair", False):
+        # xskillscore.crps_ensemble has no fair option, so compute it here.
+        return _crps_ensemble_fair(
+            verif,
+            forecast,
+            dim=dim,
+            member_dim=metric_kwargs.pop("member_dim", "member"),
+            weights=metric_kwargs.pop("weights", None),
+            keep_attrs=metric_kwargs.pop("keep_attrs", False),
+        )
     return crps_ensemble(verif, forecast, dim=dim, **metric_kwargs)
 
 

--- a/climpred/tests/test_probabilistic.py
+++ b/climpred/tests/test_probabilistic.py
@@ -237,6 +237,28 @@ def test_crps_fair_matches_manual():
     assert np.isclose(float(actual), expected)
 
 
+def test_crps_fair_ragged_ensemble_counts_non_nan_members():
+    """Fair CRPS counts non-NaN members per forecast (ragged ensembles).
+
+    Matches ``scores.probability.crps_for_ensemble(method="fair")``.
+    """
+    from climpred.metrics import __crps as crps_metric
+
+    # 5 members but 2 are NaN -> effective M = 3
+    x_full = np.array([1.0, np.nan, 3.0, 4.0, np.nan])
+    forecast = xr.DataArray(x_full, dims="member").to_dataset(name="v")
+    verif = xr.DataArray(2.0).to_dataset(name="v")
+    actual = crps_metric.function(forecast, verif, dim=["member"], fair=True)["v"]
+
+    x = x_full[~np.isnan(x_full)]  # [1, 3, 4]
+    o = 2.0
+    M = x.size  # 3, not 5
+    skill = np.abs(x - o).mean()
+    spread = np.abs(x[:, None] - x[None, :]).sum() / (2 * M * (M - 1))
+    expected = skill - spread
+    assert np.isclose(float(actual), expected)
+
+
 def test_HindcastEnsemble_rps_terciles(hindcast_hist_obs_1d):
     actual = hindcast_hist_obs_1d.isel(lead=range(3), init=range(10)).verify(
         metric="rps",

--- a/climpred/tests/test_probabilistic.py
+++ b/climpred/tests/test_probabilistic.py
@@ -208,6 +208,35 @@ def test_HindcastEnsemble_verify_probabilistic_metric_e2o_fails(
         )
 
 
+def test_HindcastEnsemble_crps_fair(hindcast_hist_obs_1d):
+    """Fair CRPS (Ferro 2014) runs, is finite and differs from the standard CRPS."""
+    he = hindcast_hist_obs_1d.isel(lead=range(3), init=range(10))
+    kwargs = dict(comparison="m2o", dim="member", alignment="same_inits")
+    standard = he.verify(metric="crps", **kwargs)
+    fair = he.verify(metric="crps", fair=True, **kwargs)
+    assert fair.notnull().all()
+    # fair estimator divides the spread term by M*(M-1) instead of M**2, so the
+    # subtracted spread is larger and fair CRPS <= standard CRPS.
+    assert (fair["SST"] <= standard["SST"] + 1e-12).all()
+    assert not np.allclose(fair["SST"], standard["SST"])
+
+
+def test_crps_fair_matches_manual():
+    """Fair CRPS matches a hand-computed reference for a tiny ensemble."""
+    from climpred.metrics import __crps as crps_metric
+
+    forecast = xr.DataArray([1.0, 3.0, 4.0], dims="member").to_dataset(name="v")
+    verif = xr.DataArray(2.0).to_dataset(name="v")
+    actual = crps_metric.function(forecast, verif, dim=["member"], fair=True)["v"]
+    x = np.array([1.0, 3.0, 4.0])
+    o = 2.0
+    M = x.size
+    skill = np.abs(x - o).mean()
+    spread = np.abs(x[:, None] - x[None, :]).sum() / (2 * M * (M - 1))
+    expected = skill - spread
+    assert np.isclose(float(actual), expected)
+
+
 def test_HindcastEnsemble_rps_terciles(hindcast_hist_obs_1d):
     actual = hindcast_hist_obs_1d.isel(lead=range(3), init=range(10)).verify(
         metric="rps",

--- a/docs/source/climpred.bib
+++ b/docs/source/climpred.bib
@@ -165,6 +165,18 @@
   doi = {10/ft272w},
 }
 
+@article{Ferro2014,
+  title = {Fair Scores for Ensemble Forecasts},
+  author = {Ferro, C. A. T.},
+  year = {2014},
+  journal = {Quarterly Journal of the Royal Meteorological Society},
+  volume = {140},
+  number = {683},
+  pages = {1917--1923},
+  issn = {1477-870X},
+  doi = {10.1002/qj.2270},
+}
+
 @article{Fransner2020,
   title = {Ocean {{Biogeochemical Predictions}}\textemdash{{Initialization}} and {{Limits}} of {{Predictability}}},
   author = {Fransner, Filippa and Counillon, Fran{\c c}ois and Bethke, Ingo and Tjiputra, Jerry and Samuelsen, Annette and Nummelin, Aleksi and Olsen, Are},


### PR DESCRIPTION
# Description

The standard ensemble CRPS estimator that backs `metric="crps"` (via `xskillscore.crps_ensemble`) is **biased for finite ensemble size** `M` — it only converges to the true CRPS as `M → ∞`. This means a mean CRPS computed from a 10-member ensemble is not directly comparable to one from a 50-member ensemble, even for equally reliable forecasts.

This PR adds a `fair=True` option to `metric="crps"` that computes the **fair CRPS** of Ferro (2014), which divides the ensemble spread term by `M(M-1)` instead of `M²`:

```
CRPS_fair = (1/M) Σ_m |x_m - o|  −  1/(2 M (M-1)) Σ_i Σ_j |x_i - x_j|
```

The result is an unbiased estimate of the CRPS the same ensemble would achieve with infinitely many members, making scores comparable across ensembles of different size. `xskillscore.crps_ensemble` has no `fair` argument (unlike `brier_score`/`rps`, which do), so the estimator is computed within climpred.

```python
HindcastEnsemble.verify(metric="crps", fair=True, comparison="m2o", dim="member", ...)
```

Default behaviour is unchanged: `fair=False` still delegates directly to `xskillscore.crps_ensemble`.

Closes #(issue) <!-- no tracking issue; opened from a skill-calculation review -->

## Type of change

-   [x]  New feature (non-breaking change which adds functionality)
-   [x]  This change requires a documentation update
-   [x]  Improved Documentation

# How Has This Been Tested?

-   [x]  Tests added for `pytest`.

Added two tests in `climpred/tests/test_probabilistic.py`:

- `test_crps_fair_matches_manual` — checks the fair estimator against a hand-computed reference on a tiny 3-member ensemble (no data download; runs in any environment).
- `test_HindcastEnsemble_crps_fair` — verifies via `HindcastEnsemble.verify` that fair CRPS is finite, differs from the standard estimator, and satisfies `fair ≤ standard` (the spread term is subtracted with the larger `M(M-1)` denominator).

Verified independently that:
- fair CRPS matches the closed-form reference (`0.3333` for members `[1,3,4]`, obs `2.0`);
- the standard path is untouched when `fair=False`;
- the member-then-average-over-init identity is preserved for the fair estimator (linearity in the reduction dimension);
- `black`, `isort`, and `flake8` pass on the changed files.

> Note: the `HindcastEnsemble`-based test could not be executed in the development sandbox because the shared fixtures download sample data over the network (blocked here); the fixture-free test and the direct-call checks were run and pass.

## Checklist (while developing)

-   [x]  I have added docstrings to all new functions.
-   [x]  I have commented my code, particularly in hard-to-understand areas.
-   [x]  I have updated the sphinx documentation (docstring + `fair` note on `metric="crps"`).
-   [x]  CHANGELOG is updated with reference to this PR.

# References

- Ferro, C. A. T. (2014). Fair scores for ensemble forecasts. *Quarterly Journal of the Royal Meteorological Society*, 140(683), 1917–1923. https://doi.org/10.1002/qj.2270 — added as `Ferro2014` in `docs/source/climpred.bib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0177aBKDDfxc1BBvw3Aq8iUi)_